### PR TITLE
Match relations to bindings using network_get

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -55,11 +55,11 @@ class VaultKVProvides(Endpoint):
         """
         for relation in self.relations:
             if remote_binding:
-                binding_info = network_get(remote_binding)
-                binding_nets = set(binding_info['egress-subnets'])
-                relation_info = network_get(self.endpoint_name,
-                                            relation.relation_id)
-                relation_nets = set(relation_info['egress-subnets'])
+                binding_nets = set(network_get(remote_binding)
+                                   ['egress-subnets'])
+                relation_nets = set(network_get(self.endpoint_name,
+                                                relation.relation_id)
+                                    ['egress-subnets'])
                 if not (binding_nets & relation_nets):
                     continue
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ commands = flake8 {posargs}
 commands = {posargs}
 
 [flake8]
-ignore = E402,E226
+ignore = E402,E226,W504


### PR DESCRIPTION
The `ingress-address` sent over the relation data is the address from the remote charm's perspective, which has no guarantee of actually being on any subnet available to the local charm (only that it will be routable). Instead, we have to use `network_get` to match the relation to the space binding based on the egress-subnets.

Additionally, `network-get --primary-address` is deprecated, so we can't use that, either.

Closes-Bug: 1843809