### PR TITLE
Provide ability to retrieve token from every remote unit

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -82,6 +82,23 @@ class VaultKVRequires(Endpoint):
         return self.all_joined_units.received.get(token_key)
 
     @property
+    def all_unit_tokens(self):
+        """Retrieve the one-shot token(s) for secret_id retrieval for
+        all application units or empty list.
+
+        :returns token: Vault one-shot token for secret_id response
+        :rtype token: str"""
+        token_key = '{}_token'.format(hookenv.local_unit())
+        tokens = set()
+        for relation in self.relations:
+            for unit in relation.units:
+                token = unit.get(token_key)
+                if token:
+                    tokens.add(token)
+
+        return list(tokens)
+
+    @property
     def vault_url(self):
         """Retrieve the URL to access Vault
 


### PR DESCRIPTION
When the remote charm has multiple units the relation may
have transient state whereby a mix of old and new tokens
are available i.e. eventually consistent. Since tokens are
one-shot and we cant tell good from bad, we need to have
all of them to be able to find a good one.

Related-Bug: #1849323