### PR TITLE
[LP#1949913] Disambiguate unit names in a vault related over CMR

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -65,6 +65,15 @@ class VaultKVProvides(Endpoint):
         # for cmr we will need to the other end to provide their unit name
         # expicitly.
         unit_name = self.get_remote_unit_name(unit)
+
+        # each unit in this relation should have one role_id, token pair associated
+        # if the unit_name shared over the relation is updated, we should clear
+        # previously associated role_id/token pairs from the relation
+        unit_id = unit_name.split("/")[1]  # the unit's id number
+        removable = f"{unit_id}_role_id", f"{unit_id}_token"
+        for key in unit.relation.to_publish.keys():
+            if any(key.endswith(r) for r in removable):
+                unit.relation.to_publish.raw_data[key] = ""  # clear this value
         unit.relation.to_publish['{}_role_id'.format(unit_name)] = role_id
         unit.relation.to_publish['{}_token'.format(unit_name)] = token
 


### PR DESCRIPTION
In an effort to disambiguate the units of a cross-model-relation to vault, each requirer will send a longer unit-name for vault to use when creating a token and role.  The requirer can handle an upgraded relation or not.

The provider should respond with the longer unit-name when providing the role_id and token, and clean up the relation removing unused role_id and tokens. 

* `requires` side states its unit_name as {model-uuid}-{local_unit}
* `provides` side filters out old role_ids and tokens

Associated with
* https://github.com/juju-solutions/layer-vault-kv/pull/20